### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP server that aggregates real-time cryptocurrency news from multiple RSS feeds, helping AI agents make informed decisions in a fast-paced market.
 
+<a href="https://glama.ai/mcp/servers/@kukapay/crypto-rss-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kukapay/crypto-rss-mcp/badge" alt="crypto-rss-mcp MCP server" />
+</a>
+
 ![GitHub License](https://img.shields.io/github/license/kukapay/crypto-trending-mcp)
 ![Python Version](https://img.shields.io/badge/python-3.10+-blue)
 ![Status](https://img.shields.io/badge/status-active-brightgreen.svg)


### PR DESCRIPTION
This PR adds a badge for the [crypto-rss-mcp](https://glama.ai/mcp/servers/@kukapay/crypto-rss-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@kukapay/crypto-rss-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kukapay/crypto-rss-mcp/badge" alt="crypto-rss-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.